### PR TITLE
Allow Robot to Be Enabled When No Joysticks are Connected Fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,6 +280,12 @@
                                     <input type="text" id="robotPort" placeholder="22211" value="22211">
                                   </div>
                                 </div>
+                                <div class="control-group">
+                                  <label class="control-label" for="inputPassword">No Joystick Enable</label>
+                                  <div class="controls">
+                                    <input type="checkbox" name="no-joy-enable" id="no-joy-en-btn">
+                                  </div>
+                                </div>
                               </form>
                             </div>
                           </div>

--- a/js/app.js
+++ b/js/app.js
@@ -165,6 +165,9 @@ define([
     // create tooltips
     $("[rel='tooltip']").tooltip();
 
+    // no joy enable
+    $("#no-joy-en-btn").bind('click', rolink.setNoJoyEnable);
+
     // load in robot config
     chrome.storage.local.get(['robotPort', 'robotIp'], function(items) {
       if (items.robotPort !== undefined) {

--- a/js/robot/robotlink.js
+++ b/js/robot/robotlink.js
@@ -53,6 +53,9 @@ define([
       // joystick count
       instance.joy_count = 0;
 
+      // no joystick enable
+      instance.no_joy_enable = false;
+
       // how we update the status model
       instance.statModel = null;
 
@@ -199,11 +202,16 @@ define([
       }
     };
 
+    RobotLink.prototype.setNoJoyEnable = function() {
+      instance.no_joy_enable = document.getElementById("no-joy-en-btn").checked;
+    }
+
     RobotLink.prototype.robot_tx = function() {
       if (instance.is_connected) {
         instance.statModel.set({connectionEnd: new Date()});
         // when the robot is disabled we must sent heartbeat frames to keep the connection alive
-        if (!instance.enabled || instance.joy_count < 1) {
+        console.log("tx");
+        if (!instance.enabled || ((instance.joy_count < 1) && !instance.no_joy_enable)) {
           var buf = new ArrayBuffer(3); // 2 bytes for each char
           var bufView = new Uint8Array(buf);
           bufView[0] = 104; // h


### PR DESCRIPTION
Add checkbox under Robot tab in Setup to allow for enabling of robot without joysticks.
