### PR TITLE
Potential Fix for Joysticks on New Versions of Chrome

### DIFF
--- a/js/gamepad/gamepad.js
+++ b/js/gamepad/gamepad.js
@@ -200,13 +200,14 @@ define([
 
       // We only refresh the display when we detect some gamepads are new
       // or removed; we do it by comparing raw gamepad table entries to
-      // “undefined.”
+      // null.”
       var gamepadsChanged = false;
 
       for (var i = 0; i < rawGamepads.length; i++) {
-        if (typeof rawGamepads[i] != prevRawGamepadTypes[i]) {
+        var gamepadState = (rawGamepads[i] == null)?false:true;
+        if (gamepadState != prevRawGamepadTypes[i]) {
           gamepadsChanged = true;
-          prevRawGamepadTypes[i] = typeof rawGamepads[i];
+          prevRawGamepadTypes[i] = gamepadState;
         }
 
         if (rawGamepads[i]) {

--- a/js/gamepad/gamepad.js
+++ b/js/gamepad/gamepad.js
@@ -200,7 +200,7 @@ define([
 
       // We only refresh the display when we detect some gamepads are new
       // or removed; we do it by comparing raw gamepad table entries to
-      // null or undefined.”
+      // "null" or "undefined.”
       var gamepadsChanged = false;
 
       for (var i = 0; i < rawGamepads.length; i++) {

--- a/js/gamepad/gamepad.js
+++ b/js/gamepad/gamepad.js
@@ -200,11 +200,11 @@ define([
 
       // We only refresh the display when we detect some gamepads are new
       // or removed; we do it by comparing raw gamepad table entries to
-      // null.”
+      // null or undefined.”
       var gamepadsChanged = false;
 
       for (var i = 0; i < rawGamepads.length; i++) {
-        var gamepadState = (rawGamepads[i] == null)?false:true;
+        var gamepadState = (rawGamepads[i] == null || rawGamepads[i] == undefined)?false:true;
         if (gamepadState != prevRawGamepadTypes[i]) {
           gamepadsChanged = true;
           prevRawGamepadTypes[i] = gamepadState;


### PR DESCRIPTION
This still warrants more testing as I only had one XBox 360 Clone controller to test with, but what I was able to test works beautifully. I also haven't been able to test Chrome 53 since that is officially being recommended, as I don't have a Windows machine handy.

Not sure if there were previous issues that have since been resolved, but it looks like the issue here is that somewhere along the way, "empty" joysticks went from being `undefined` to `null` in the array returned by `navigator.getGamepads()`. Unfortunately `typeof null` is `'object'` as is the type of an actual Gamepad object, so no changes to the array were being processed. I have re-worked the logic to use true/false and check explicitly for null. Possible this could break again in the future I guess, but it does seem to work now. 

fix #15 