### PR TITLE
Blur Enable Button after press to ensure Spacebar Disable functions

### DIFF
--- a/js/views/buttons.js
+++ b/js/views/buttons.js
@@ -25,6 +25,7 @@ define([
     $("#enable-btn").html('Disable Robot');
     $("#enable-btn").removeClass('btn-info');
     $("#enable-btn").addClass('btn-warning');
+    $("#enable-btn").blur();
     $("#disablehint").show();
   };
 
@@ -33,6 +34,7 @@ define([
     $("#enable-btn").html('Enable Robot');
     $("#enable-btn").removeClass('btn-warning');
     $("#enable-btn").addClass('btn-info');
+    $("#enable-btn").blur();
     $("#disablehint").hide();
   };
 


### PR DESCRIPTION
If the last action in the DriverStation was enabling the robot, the button will still have focus and pressing the spacebar to disable will also toggle the Enable Robot button and result in cycling the robot state and NOT disabling the robot.

This change unfocuses the Enable Button after it is pressed to ensure that pressing the spacebar will disable the robot. 